### PR TITLE
Update the header banner to update the design from the TDDA.

### DIFF
--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -56,6 +56,16 @@
   {{ ccsHeader({
     serviceName: "Nom du service",
     containerClasses: "app-width-container--wide",
+    serviceAuthentication: [
+      {
+        href: '#1',
+        text: "inscrire"
+      },
+      {
+        href: '#2',
+        text: 'ouvrir une session'
+      }
+    ],
     navigationPrimary: [
       {
         href: '#1',

--- a/app/views/full-page-examples/facilities-management/index.njk
+++ b/app/views/full-page-examples/facilities-management/index.njk
@@ -21,7 +21,17 @@ scenario: >-
 
 {% block header %}
   {{ ccsHeader({
-    serviceName: 'Find a facilities management supplier'
+    serviceName: 'Find a facilities management supplier',
+    serviceAuthentication: [
+      {
+        href: '#1',
+        text: "Register"
+      },
+      {
+        href: '#2',
+        text: 'Sign in'
+      }
+    ]
   }) }}
   <div class="govuk-width-container ">
     {{ govukPhaseBanner({

--- a/src/ccs/components/header/_index.scss
+++ b/src/ccs/components/header/_index.scss
@@ -1,7 +1,6 @@
 @include ccs-exports("ccs/component/ccs-header") {
   $ccs-header-background: $ccs-brand-colour;
-  $ccs-header-border-color: ccs-colour("blue");
-  $ccs-header-border-width: govuk-spacing(2);
+  $ccs-header-service-authentication-background: ccs-colour("black");
   $ccs-header-text: ccs-colour("white");
   $ccs-header-link-active-border-color: ccs-colour("white");
   $ccs-header-nav-item-border-color: ccs-colour("dark-red");
@@ -17,19 +16,50 @@
 
   .ccs-header__container--full-width {
     padding: 0 govuk-spacing(3);
-    border-color: $ccs-header-border-color;
 
     .ccs-header__menu-button {
       right: govuk-spacing(3);
     }
   }
 
-  .ccs-header__container {
+  .ccs-header__container,
+  .ccs-header__service-authentication-container {
     @include govuk-clearfix;
     position: relative;
-    margin-bottom: -$ccs-header-border-width;
+  }
+
+  .ccs-header__container {
     padding-top: govuk-spacing(2);
-    border-bottom: $ccs-header-border-width solid $ccs-header-border-color;
+  }
+
+  .ccs-header__service-authentication-container {
+    padding-top: govuk-spacing(1);
+    padding-bottom: govuk-spacing(1);
+  }
+
+  .ccs-header__service-authentication {
+    background: $ccs-header-service-authentication-background;
+    text-align: right;
+  }
+
+  .ccs-header__service-authentication-item {
+    display: inline-block;
+    margin-right: govuk-spacing(3);
+    padding: govuk-spacing(2) 0;
+    border: 0;
+
+    @include govuk-media-query ($from: desktop) {
+      padding: govuk-spacing(1) 0;
+    }
+
+    a {
+      @include govuk-font($size: 16, $weight: regular);
+    }
+  }
+
+  .ccs-header__service-authentication-list .ccs-header__service-authentication-item:last-child {
+    margin-right: 0;
+    border-bottom: 0;
   }
 
   .ccs-header__link {
@@ -120,10 +150,9 @@
       width: 75%;
       padding-left: $govuk-gutter-half;
       float: left;
-      text-align: right;
     }
   }
-  // text-align: right;
+
   .ccs-header__menu-button {
     @include govuk-font($size: 16);
     display: none;
@@ -172,6 +201,7 @@
     }
   }
 
+  .ccs-header__service-authentication-list,
   .ccs-header__navigation-primary-list,
   .ccs-header__navigation-secondary-list {
     // Reset user-agent default list styles

--- a/src/ccs/components/header/header.yaml
+++ b/src/ccs/components/header/header.yaml
@@ -15,6 +15,27 @@ params:
   type: string
   required: false
   description: URL for the service name anchor.
+- name: serviceAuthentication
+  type: array
+  required: false
+  description: An array of authentication item objects (for example sign-in or register). Is placed at the top of the header.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: Text for the authentication item. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: HTML for the authentication item. If `html` is provided, the `text` argument will be ignored.
+  - name: href
+    type: string
+    required: false
+    description: URL of the authentication item anchor.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the navigation item anchor.
 - name: navigationPrimary
   type: array
   required: false
@@ -122,6 +143,15 @@ examples:
     serviceName: Service Name
     serviceUrl: '/components/ccs-header'
 
+- name: with authentication options
+  description: If your service reuires users to log in to access it, this section can contain the links for the authentication
+  data:
+    serviceAuthentication:
+      - href: '#1'
+        text: Register
+      - href: '#2'
+        text: Sign in
+
 - name: with both navigation
   data:
     navigationPrimary:
@@ -196,11 +226,16 @@ examples:
       - href: '#4'
         text: Navigation item 4
 
-- name: with service name and navigation
+- name: with service name, authentication and navigation
   description: If you need to include basic navigation, contact or account management links.
   data:
     serviceName: Service Name
     serviceUrl: '/components/ccs-header'
+    serviceAuthentication:
+      - href: '#1'
+        text: Register
+      - href: '#2'
+        text: Sign in
     navigationPrimary:
       - href: '#1'
         text: Navigation item 1
@@ -285,10 +320,15 @@ examples:
     containerClasses: ccs-header__container--full-width
     navigationClasses: ccs-header__navigation--end
 
-- name: full width with navigation
+- name: full width with navigation and service authentication
   data:
     containerClasses: ccs-header__container--full-width
     navigationClasses: ccs-header__navigation--end
+    serviceAuthentication:
+      - href: '#1'
+        text: Register
+      - href: '#2'
+        text: Sign in
     navigationPrimary:
       - href: '#1'
         text: Navigation item 1

--- a/src/ccs/components/header/template.njk
+++ b/src/ccs/components/header/template.njk
@@ -2,6 +2,27 @@
 
 <header class="ccs-header {{ params.classes if params.classes }}" role="banner" data-module="ccs-header"
         {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {% if params.serviceAuthentication %}
+    <div class="ccs-header__service-authentication">
+      <div class="ccs-header__service-authentication-container {{ params.containerClasses | default('govuk-width-container') }}">
+        <ul class="ccs-header__service-authentication-list">
+          {% for item in params.serviceAuthentication %}
+            {% if item.text or item.html %}
+              <li class="ccs-header__service-authentication-item">
+                {% if item.href %}
+                  <a class="ccs-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+                {% endif %}
+                  {{ item.html | safe if item.html else item.text }}
+                {% if item.href %}
+                  </a>
+                {% endif %}
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  {% endif %}
   <div class="ccs-header__container {{ params.containerClasses | default('govuk-width-container') }}">
     <div class="ccs-header__logo">
       <a href="{{ params.homepageUrl | default('https://www.crowncommercial.gov.uk') }}" class="ccs-header__link ccs-header__link--homepage" aria-label="Crown Commercial Service">

--- a/src/ccs/components/header/template.test.js
+++ b/src/ccs/components/header/template.test.js
@@ -52,7 +52,7 @@ describe('header', () => {
     })
 
     it('renders custom navigation classes', () => {
-      const $ = render('header', examples['full width with navigation'])
+      const $ = render('header', examples['full width with navigation and service authentication'])
 
       const $component = $('.ccs-header')
       const $container = $component.find('.ccs-header__navigation')
@@ -235,6 +235,33 @@ describe('header', () => {
 
         expect($component.hasClass('ccs-header__navigation--no-second-list')).toBeTruthy()
       })
+    })
+  })
+
+  describe('with service name, authentication and navigation', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('header', examples['with service name, authentication and navigation'])
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders the service authentication', () => {
+      const $ = render('header', examples['with service name, authentication and navigation'])
+
+      const $component = $('.ccs-header')
+      const $authenticationSection = $component.find('div.ccs-header__service-authentication')
+
+      const $authenticationList = $authenticationSection.find('ul.ccs-header__service-authentication-list')
+
+      const $authenticationItems = $authenticationList.find('li.ccs-header__service-authentication-item')
+
+      const $firstAuthenticationItem = $authenticationItems.find('a.ccs-header__link:first-child')
+
+      expect($authenticationItems.length).toEqual(2)
+
+      expect($firstAuthenticationItem.attr('href')).toEqual('#1')
+      expect($firstAuthenticationItem.text()).toContain('Register')
     })
   })
 })

--- a/src/ccs/settings/_colours-palette.scss
+++ b/src/ccs/settings/_colours-palette.scss
@@ -17,7 +17,6 @@
 $ccs-colours: (
   "red": #9b1a47,
   "dark-red": #85163d,
-  "blue": #1d70b8,
   "white": #ffffff,
 
   "mid-grey": #b1b4b6,


### PR DESCRIPTION
Update the header banner to update the [design from the TDDA](https://crowncommercialservice.atlassian.net/wiki/spaces/AG/pages/3196256264/CCS+Digital+Services+Header+and+Footer+Standards).

This involved making the text in the banner left justified and adding a section at the top for links that deal with service authentication (Register, Sign in, Sign out etc.).

I added tests also to make sure that the header remained accessible.

Below is an example of what a header may look like.
<img width="1015" alt="Screenshot 2022-04-29 at 08 45 01" src="https://user-images.githubusercontent.com/58297459/165903909-995747d9-72a1-4b66-b977-82ed55469894.png">